### PR TITLE
Change: Participants who unregister from an event are only hidden and not removed from the table

### DIFF
--- a/config/autoload/project.global.php.dist
+++ b/config/autoload/project.global.php.dist
@@ -14,5 +14,10 @@ return [
                 ]
             ]
         ]
+    ],
+    'event' => [
+        'participant' => [
+            'subscribe_delay' => 30
+        ]
     ]
 ];

--- a/database/migrations/Version20220921202028CreateParticipantTable.php
+++ b/database/migrations/Version20220921202028CreateParticipantTable.php
@@ -20,6 +20,7 @@ final class Version20220921202028CreateParticipantTable extends AbstractMigratio
         $table->addColumn('approved', Types::BOOLEAN, ['default' => true,]);
         $table->addColumn('disqualified', Types::BOOLEAN, ['default' => false]);
         $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['userId', 'eventId'], 'UNIQUE_USER_EVENT');
     }
 
     public function down(Schema $schema): void

--- a/database/migrations/Version20220921202028CreateParticipantTable.php
+++ b/database/migrations/Version20220921202028CreateParticipantTable.php
@@ -16,9 +16,9 @@ final class Version20220921202028CreateParticipantTable extends AbstractMigratio
         $table->addColumn('userId', Types::INTEGER, ['unsigned' => true]);
         $table->addColumn('eventId', Types::INTEGER, ['unsigned' => true]);
         $table->addColumn('requestTime', Types::DATETIME_IMMUTABLE, ['default' => 'CURRENT_TIMESTAMP']);
+        $table->addColumn('subscribed', Types::BOOLEAN, ['default' => true]);
         $table->addColumn('approved', Types::BOOLEAN, ['default' => true,]);
         $table->addColumn('disqualified', Types::BOOLEAN, ['default' => false]);
-
         $table->setPrimaryKey(['id']);
     }
 

--- a/src/App/Model/Participant.php
+++ b/src/App/Model/Participant.php
@@ -10,6 +10,7 @@ class Participant
     private int $userId = 0;
     private int $eventId = 0;
     private DateTime $requestTime;
+    private bool $subscribed = true;
     private bool $approved = false;
     private bool $disqualified = true;
 
@@ -62,6 +63,18 @@ class Participant
     public function setRequestTime(DateTime $requestTime): self
     {
         $this->requestTime = $requestTime;
+
+        return $this;
+    }
+
+    public function isSubscribed(): bool
+    {
+        return $this->subscribed;
+    }
+
+    public function setSubscribed(int|bool $subscribed): self
+    {
+        $this->subscribed = (bool)$subscribed;
 
         return $this;
     }

--- a/src/App/Service/ParticipantService.php
+++ b/src/App/Service/ParticipantService.php
@@ -26,7 +26,7 @@ class ParticipantService
 
     public function remove(Participant $participant): bool
     {
-        return $this->table->remove($participant) == 0 ? false : true;
+        return (int)$this->table->remove($participant) !== 0;
     }
 
     public function findById(int $id): Participant

--- a/src/App/Table/ParticipantTable.php
+++ b/src/App/Table/ParticipantTable.php
@@ -40,6 +40,7 @@ class ParticipantTable extends AbstractTable
         return $this->query->from(($this->table))
             ->where('userId', $userId)
             ->where('eventId', $eventId)
+            ->where('subscribed', true)
             ->fetch();
     }
 
@@ -47,6 +48,7 @@ class ParticipantTable extends AbstractTable
     {
         return $this->query->from($this->table)
             ->where('eventId', $eventId)
+            ->where('subscribed', true)
             ->where('approved', 1)
             ->where('disqualified', 0)
             ->fetchAll();

--- a/src/App/Table/ParticipantTable.php
+++ b/src/App/Table/ParticipantTable.php
@@ -15,14 +15,14 @@ class ParticipantTable extends AbstractTable
         ];
 
         return (int)$this->query->insertInto($this->table, $values)
-            ->onDuplicateKeyUpdate(['subscribed' => true])
+            ->onDuplicateKeyUpdate(['subscribed' => 1])
             ->execute();
     }
 
     public function remove(Participant $participant): int|bool
     {
         return (int)$this->query->update($this->table)
-            ->set(['subscribed'], false)
+            ->set('subscribed', 0)
             ->where('userId', $participant->getUserId())
             ->where('eventId', $participant->getEventId())
             ->execute();

--- a/src/App/Table/ParticipantTable.php
+++ b/src/App/Table/ParticipantTable.php
@@ -14,12 +14,15 @@ class ParticipantTable extends AbstractTable
             'approved' => $participant->isApproved(),
         ];
 
-        return (int)$this->query->insertInto($this->table, $values)->execute();
+        return (int)$this->query->insertInto($this->table, $values)
+            ->onDuplicateKeyUpdate(['subscribed' => true])
+            ->execute();
     }
 
     public function remove(Participant $participant): int|bool
     {
-        return (int)$this->query->delete($this->table)
+        return (int)$this->query->update($this->table)
+            ->set(['subscribed'], false)
             ->where('userId', $participant->getUserId())
             ->where('eventId', $participant->getEventId())
             ->execute();

--- a/src/App/Table/ParticipantTable.php
+++ b/src/App/Table/ParticipantTable.php
@@ -22,7 +22,7 @@ class ParticipantTable extends AbstractTable
     public function remove(Participant $participant): int|bool
     {
         return (int)$this->query->update($this->table)
-            ->set('subscribed', 0)
+            ->set(['subscribed' => 0])
             ->where('userId', $participant->getUserId())
             ->where('eventId', $participant->getEventId())
             ->execute();
@@ -40,7 +40,7 @@ class ParticipantTable extends AbstractTable
         return $this->query->from(($this->table))
             ->where('userId', $userId)
             ->where('eventId', $eventId)
-            ->where('subscribed', true)
+            ->where('subscribed', 1)
             ->fetch();
     }
 
@@ -48,7 +48,7 @@ class ParticipantTable extends AbstractTable
     {
         return $this->query->from($this->table)
             ->where('eventId', $eventId)
-            ->where('subscribed', true)
+            ->where('subscribed', 1)
             ->where('approved', 1)
             ->where('disqualified', 0)
             ->fetchAll();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Previously, attendees who unsubscribe from an event were removed from the corresponding database table.
This led to the fact, if these have registered nevertheless again with the Event, that the participant got a completely new participant number.

The deregistration from an event is now only done via a flag entry in the database.

Further restrictions are then further processed with Issues #118 .

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- see how your change affects other areas of the code, etc. -->
Test by unit test and manual check and triage in the database

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --> 
- [ ] Feature <!--- (mark pull request with Feat:) -->
- [ ] Bug fix <!--- (mark pull request with Fix:) -->
- [ ] Refactor <!--- (mark pull request with Refactor:) -->
- [X] Change <!--- (mark pull request with Change:) -->
- [ ] Style <!--- (mark pull request with Style:) -->
- [ ] Docs <!--- (mark pull request with Docs:) -->
- [ ] Test <!--- (mark pull request with Test:) -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **Contributing Guide** was read.
- If change in a documentation required:
  - [ ] Documentation was adjusted
- [X] Tests added to cover changes
